### PR TITLE
Add trigger to remove duplicate posts on db

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ db = sqlite3.connect("toots.db")
 db.text_factory=str
 c = db.cursor()
 c.execute("CREATE TABLE IF NOT EXISTS `toots` (sortid INTEGER UNIQUE PRIMARY KEY AUTOINCREMENT, id VARCHAR NOT NULL, cw INT NOT NULL DEFAULT 0, userid VARCHAR NOT NULL, uri VARCHAR NOT NULL, content VARCHAR NOT NULL)")
-c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY id ); END; ")
+c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY uri ); END; ")
 db.commit()
 
 tableinfo = c.execute("PRAGMA table_info(`toots`)").fetchall()
@@ -122,7 +122,7 @@ if not found:
 
 	c.execute("DROP TABLE `toots`")
 	c.execute("ALTER TABLE `toots_temp` RENAME TO `toots`")
-	c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY id ); END; ")
+	c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY uri ); END; ")
 
 db.commit()
 

--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ db = sqlite3.connect("toots.db")
 db.text_factory=str
 c = db.cursor()
 c.execute("CREATE TABLE IF NOT EXISTS `toots` (sortid INTEGER UNIQUE PRIMARY KEY AUTOINCREMENT, id VARCHAR NOT NULL, cw INT NOT NULL DEFAULT 0, userid VARCHAR NOT NULL, uri VARCHAR NOT NULL, content VARCHAR NOT NULL)")
+c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY id ); END; ")
 db.commit()
 
 tableinfo = c.execute("PRAGMA table_info(`toots`)").fetchall()
@@ -121,6 +122,7 @@ if not found:
 
 	c.execute("DROP TABLE `toots`")
 	c.execute("ALTER TABLE `toots_temp` RENAME TO `toots`")
+	c.execute("CREATE TRIGGER IF NOT EXISTS `dedup` AFTER INSERT ON toots FOR EACH ROW BEGIN DELETE FROM toots WHERE rowid NOT IN (SELECT MIN(sortid) FROM toots GROUP BY id ); END; ")
 
 db.commit()
 


### PR DESCRIPTION
Hi, your repo had the latest commit so I hope you don't mind if I send you this.

I noticed that there were repeated posts in the database (I think the reason is if main.py is run before a new post is made by the account/s the bot is following but this is empirical, I didn't check the code), I know some programing but I took the shortest path and simply fixed the problem by creating a trigger in sqlite that removes repeated posts instead of actually fixing the root cause.